### PR TITLE
Miasma has been neutered.

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -72,7 +72,7 @@
 #define WALL_HEAT_TRANSFER_COEFFICIENT		0.0
 #define OPEN_HEAT_TRANSFER_COEFFICIENT		0.4
 /// a hack for now
-#define WINDOW_HEAT_TRANSFER_COEFFICIENT	0.1	
+#define WINDOW_HEAT_TRANSFER_COEFFICIENT	0.1
 /// a hack to help make vacuums "cold", sacrificing realism for gameplay
 #define HEAT_CAPACITY_VACUUM				7000
 
@@ -104,7 +104,7 @@
 
 // Pressure limits.
 /// This determins at what pressure the ultra-high pressure red icon is displayed. (This one is set as a constant)
-#define HAZARD_HIGH_PRESSURE				550	
+#define HAZARD_HIGH_PRESSURE				550
 /// This determins when the orange pressure icon is displayed (it is 0.7 * HAZARD_HIGH_PRESSURE)
 #define WARNING_HIGH_PRESSURE				325
 /// This is when the gray low pressure icon is displayed. (it is 2.5 * HAZARD_LOW_PRESSURE)
@@ -393,5 +393,5 @@ GLOBAL_LIST_INIT(pipe_paint_colors, sortList(list(
 		"yellow" = rgb(255,198,0)
 )))
 
-#define MIASMA_CORPSE_MOLES 0.02
-#define MIASMA_GIBS_MOLES 0.005
+#define MIASMA_CORPSE_MOLES 0.00
+#define MIASMA_GIBS_MOLES 0.000

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -469,32 +469,32 @@
 			air.temperature = max(((air.temperature*old_heat_capacity - energy_taken)/new_heat_capacity),TCMB)
 
 
-/datum/gas_reaction/miaster	//dry heat sterilization: clears out pathogens in the air
-	priority = -10 //after all the heating from fires etc. is done
-	name = "Dry Heat Sterilization"
-	id = "sterilization"
+///datum/gas_reaction/miaster	//dry heat sterilization: clears out pathogens in the air
+	//priority = -10 //after all the heating from fires etc. is done
+	//name = "Dry Heat Sterilization"
+	//id = "sterilization"
 
-/datum/gas_reaction/miaster/init_reqs()
-	min_requirements = list(
-		"TEMP" = FIRE_MINIMUM_TEMPERATURE_TO_EXIST+70,
-		/datum/gas/miasma = MINIMUM_MOLE_COUNT
-	)
+///datum/gas_reaction/miaster/init_reqs()
+	//min_requirements = list(
+	//	"TEMP" = FIRE_MINIMUM_TEMPERATURE_TO_EXIST+70,
+	//	/datum/gas/miasma = MINIMUM_MOLE_COUNT
+//	)
 
-/datum/gas_reaction/miaster/react(datum/gas_mixture/air, datum/holder)
-	var/list/cached_gases = air.gases
+///datum/gas_reaction/miaster/react(datum/gas_mixture/air, datum/holder)
+	//var/list/cached_gases = air.gases
 	// As the name says it, it needs to be dry
-	if(cached_gases[/datum/gas/water_vapor] && cached_gases[/datum/gas/water_vapor][MOLES]/air.total_moles() > 0.1)
-		return
+	//if(cached_gases[/datum/gas/water_vapor] && cached_gases[/datum/gas/water_vapor][MOLES]/air.total_moles() > 0.1)
+	//	return
 
 	//Replace miasma with oxygen
-	var/cleaned_air = min(cached_gases[/datum/gas/miasma][MOLES], 20 + (air.temperature - FIRE_MINIMUM_TEMPERATURE_TO_EXIST - 70) / 20)
-	cached_gases[/datum/gas/miasma][MOLES] -= cleaned_air
-	ASSERT_GAS(/datum/gas/oxygen,air)
-	cached_gases[/datum/gas/oxygen][MOLES] += cleaned_air
+	//var/cleaned_air = min(cached_gases[/datum/gas/miasma][MOLES], 20 + (air.temperature - FIRE_MINIMUM_TEMPERATURE_TO_EXIST - 70) / 20)
+	//cached_gases[/datum/gas/miasma][MOLES] -= cleaned_air
+	//ASSERT_GAS(/datum/gas/oxygen,air)
+	//cached_gases[/datum/gas/oxygen][MOLES] += cleaned_air
 
 	//Possibly burning a bit of organic matter through maillard reaction, so a *tiny* bit more heat would be understandable
-	air.temperature += cleaned_air * 0.002
-	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, cleaned_air*MIASMA_RESEARCH_AMOUNT)//Turns out the burning of miasma is kinda interesting to scientists
+	//air.temperature += cleaned_air * 0.002
+	//SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, cleaned_air*MIASMA_RESEARCH_AMOUNT)//Turns out the burning of miasma is kinda interesting to scientists
 
 /datum/gas_reaction/stim_ball
 	priority = 7

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -46,21 +46,21 @@
 			START_PROCESSING(SSobj, src)
 	return ..()
 
-/obj/item/seeds/starthistle/corpse_flower/process()
-	var/obj/machinery/hydroponics/parent = loc
-	if(parent.age < maturation) // Start a little before it blooms
-		return
+///obj/item/seeds/starthistle/corpse_flower/process()
+	//var/obj/machinery/hydroponics/parent = loc
+	//if(parent.age < maturation) // Start a little before it blooms
+	//	return
 
-	var/turf/open/T = get_turf(parent)
-	if(abs(ONE_ATMOSPHERE - T.return_air().return_pressure()) > (potency/10 + 10)) // clouds can begin showing at around 50-60 potency in standard atmos
-		return
+	//var/turf/open/T = get_turf(parent)
+	//if(abs(ONE_ATMOSPHERE - T.return_air().return_pressure()) > (potency/10 + 10)) // clouds can begin showing at around 50-60 potency in standard atmos
+	//	return
 
-	var/datum/gas_mixture/stank = new
-	ADD_GAS(/datum/gas/miasma, stank.gases)
-	stank.gases[/datum/gas/miasma][MOLES] = (yield + 6)*7*MIASMA_CORPSE_MOLES // this process is only being called about 2/7 as much as corpses so this is 12-32 times a corpses
-	stank.temperature = T20C // without this the room would eventually freeze and miasma mining would be easier
-	T.assume_air(stank)
-	T.air_update_turf()
+	//var/datum/gas_mixture/stank = new
+	//ADD_GAS(/datum/gas/miasma, stank.gases)
+	//stank.gases[/datum/gas/miasma][MOLES] = (yield + 6)*7*MIASMA_CORPSE_MOLES // this process is only being called about 2/7 as much as corpses so this is 12-32 times a corpses
+	//stank.temperature = T20C // without this the room would eventually freeze and miasma mining would be easier
+	//T.assume_air(stank)
+	//T.air_update_turf()
 
 //Galaxy Thistle
 /obj/item/seeds/galaxythistle

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -35,7 +35,7 @@
 
 	if(stat == DEAD)
 		stop_sound_channel(CHANNEL_HEARTBEAT)
-		LoadComponent(/datum/component/rot/corpse)
+	//	LoadComponent(/datum/component/rot/corpse)
 
 	check_cremation()
 
@@ -250,45 +250,45 @@
 		adjustFireLoss(nitryl_partialpressure/4)
 
 	//MIASMA
-	if(breath_gases[/datum/gas/miasma])
-		var/miasma_partialpressure = (breath_gases[/datum/gas/miasma][MOLES]/breath.total_moles())*breath_pressure
+	//if(breath_gases[/datum/gas/miasma])
+	//	var/miasma_partialpressure = (breath_gases[/datum/gas/miasma][MOLES]/breath.total_moles())*breath_pressure
 
-		if(prob(1 * miasma_partialpressure))
-			var/datum/disease/advance/miasma_disease = new /datum/disease/advance/random(2,3)
-			miasma_disease.name = "Unknown"
-			ForceContractDisease(miasma_disease, TRUE, TRUE)
+	//	if(prob(1 * miasma_partialpressure))
+	//		var/datum/disease/advance/miasma_disease = new /datum/disease/advance/random(2,3)
+	//		miasma_disease.name = "Unknown"
+	//		ForceContractDisease(miasma_disease, TRUE, TRUE)
 
 		//Miasma side effects
-		switch(miasma_partialpressure)
-			if(0.25 to 5)
-				// At lower pp, give out a little warning
-				SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "smell")
-				if(prob(5))
-					to_chat(src, "<span class='notice'>There is an unpleasant smell in the air.</span>")
-			if(5 to 20)
-				//At somewhat higher pp, warning becomes more obvious
-				if(prob(15))
-					to_chat(src, "<span class='warning'>You smell something horribly decayed inside this room.</span>")
-					SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "smell", /datum/mood_event/disgust/bad_smell)
-			if(15 to 30)
-				//Small chance to vomit. By now, people have internals on anyway
-				if(prob(5))
-					to_chat(src, "<span class='warning'>The stench of rotting carcasses is unbearable!</span>")
-					SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "smell", /datum/mood_event/disgust/nauseating_stench)
-					vomit()
-			if(30 to INFINITY)
-				//Higher chance to vomit. Let the horror start
-				if(prob(25))
-					to_chat(src, "<span class='warning'>The stench of rotting carcasses is unbearable!</span>")
-					SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "smell", /datum/mood_event/disgust/nauseating_stench)
-					vomit()
-			else
-				SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "smell")
+	//	switch(miasma_partialpressure)
+	//		if(0.25 to 5)
+	//			// At lower pp, give out a little warning
+	//			SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "smell")
+	//			if(prob(5))
+	///				to_chat(src, "<span class='notice'>There is an unpleasant smell in the air.</span>")
+	//		if(5 to 20)
+	//			//At somewhat higher pp, warning becomes more obvious
+	//			if(prob(15))
+	//				to_chat(src, "<span class='warning'>You smell something horribly decayed inside this room.</span>")
+	//				SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "smell", /datum/mood_event/disgust/bad_smell)
+	//		if(15 to 30)
+	//			//Small chance to vomit. By now, people have internals on anyway
+	//			if(prob(5))
+	//				to_chat(src, "<span class='warning'>The stench of rotting carcasses is unbearable!</span>")
+	//				SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "smell", /datum/mood_event/disgust/nauseating_stench)
+	//				vomit()
+	//		if(30 to INFINITY)
+	//			//Higher chance to vomit. Let the horror start
+	//			if(prob(25))
+	//				to_chat(src, "<span class='warning'>The stench of rotting carcasses is unbearable!</span>")
+	//				SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "smell", /datum/mood_event/disgust/nauseating_stench)
+	//				vomit()
+	//		else
+	//			SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "smell")
 
 
 	//Clear all moods if no miasma at all
-	else
-		SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "smell")
+	//else
+	//	SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "smell")
 
 
 

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -292,52 +292,52 @@
 		breath_gases[/datum/gas/stimulum][MOLES]-=gas_breathed
 
 	// Miasma
-		if (breath_gases[/datum/gas/miasma])
-			var/miasma_pp = breath.get_breath_partial_pressure(breath_gases[/datum/gas/miasma][MOLES])
+	//	if (breath_gases[/datum/gas/miasma])
+	//		var/miasma_pp = breath.get_breath_partial_pressure(breath_gases[/datum/gas/miasma][MOLES])
 
 			//Miasma sickness
-			if(prob(0.5 * miasma_pp))
-				var/datum/disease/advance/miasma_disease = new /datum/disease/advance/random(min(round(max(miasma_pp/2, 1), 1), 6), min(round(max(miasma_pp, 1), 1), 8))
+	//		if(prob(0.5 * miasma_pp))
+	//			var/datum/disease/advance/miasma_disease = new /datum/disease/advance/random(min(round(max(miasma_pp/2, 1), 1), 6), min(round(max(miasma_pp, 1), 1), 8))
 				//tl;dr the first argument chooses the smaller of miasma_pp/2 or 6(typical max virus symptoms), the second chooses the smaller of miasma_pp or 8(max virus symptom level) //
-				miasma_disease.name = "Unknown"//^each argument has a minimum of 1 and rounds to the nearest value. Feel free to change the pp scaling I couldn't decide on good numbers for it.
-				miasma_disease.try_infect(owner)
+	//			miasma_disease.name = "Unknown"//^each argument has a minimum of 1 and rounds to the nearest value. Feel free to change the pp scaling I couldn't decide on good numbers for it.
+	//			miasma_disease.try_infect(owner)
 
 			// Miasma side effects
-			switch(miasma_pp)
-				if(0.25 to 5)
-					// At lower pp, give out a little warning
-					SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "smell")
-					if(prob(5))
-						to_chat(owner, "<span class='notice'>There is an unpleasant smell in the air.</span>")
-				if(5 to 15)
+	//		switch(miasma_pp)
+	//			if(0.25 to 5)
+	//				// At lower pp, give out a little warning
+	//				SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "smell")
+	//				if(prob(5))
+	//					to_chat(owner, "<span class='notice'>There is an unpleasant smell in the air.</span>")
+	//			if(5 to 15)
 					//At somewhat higher pp, warning becomes more obvious
-					if(prob(15))
-						to_chat(owner, "<span class='warning'>You smell something horribly decayed inside this room.</span>")
-						SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "smell", /datum/mood_event/disgust/bad_smell)
-				if(15 to 30)
+	//				if(prob(15))
+	//					to_chat(owner, "<span class='warning'>You smell something horribly decayed inside this room.</span>")
+	//					SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "smell", /datum/mood_event/disgust/bad_smell)
+	//			if(15 to 30)
 					//Small chance to vomit. By now, people have internals on anyway
-					if(prob(5))
-						to_chat(owner, "<span class='warning'>The stench of rotting carcasses is unbearable!</span>")
-						SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "smell", /datum/mood_event/disgust/nauseating_stench)
-						owner.vomit()
-				if(30 to INFINITY)
+	//				if(prob(5))
+	//					to_chat(owner, "<span class='warning'>The stench of rotting carcasses is unbearable!</span>")
+	//					SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "smell", /datum/mood_event/disgust/nauseating_stench)
+	//					owner.vomit()
+	//			if(30 to INFINITY)
 					//Higher chance to vomit. Let the horror start
-					if(prob(15))
-						to_chat(owner, "<span class='warning'>The stench of rotting carcasses is unbearable!</span>")
-						SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "smell", /datum/mood_event/disgust/nauseating_stench)
-						owner.vomit()
-				else
-					SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "smell")
+	//				if(prob(15))
+	//					to_chat(owner, "<span class='warning'>The stench of rotting carcasses is unbearable!</span>")
+	//					SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "smell", /datum/mood_event/disgust/nauseating_stench)
+	//					owner.vomit()
+	//			else
+	//				SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "smell")
 
 			// In a full miasma atmosphere with 101.34 pKa, about 10 disgust per breath, is pretty low compared to threshholds
 			// Then again, this is a purely hypothetical scenario and hardly reachable
-			owner.adjust_disgust(0.1 * miasma_pp)
+	//		owner.adjust_disgust(0.1 * miasma_pp)
 
-			breath_gases[/datum/gas/miasma][MOLES]-=gas_breathed
+	//		breath_gases[/datum/gas/miasma][MOLES]-=gas_breathed
 
 		// Clear out moods when no miasma at all
-		else
-			SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "smell")
+	//	else
+	//		SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "smell")
 
 		handle_breath_temperature(breath, H)
 		breath.garbage_collect()


### PR DESCRIPTION
Code itself has been left intact (and commented out) for repurposing later. But currently Miasma is functionless beyond its innate values/atmospheric coloring.

Notable is that Miasma can no longer burn. Making it harder to initiate fusion. The _per lifetick disease spawning_ has also been removed. Gibs can still rot, they just won't make any miasma.

As should be standard, has been tested on local, review as ya whim.